### PR TITLE
Error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ module.exports = function createServers(options, listening) {
 
       if (errors.http || errors.https) {
         return listening(errs.create({
+          message: (errors.https || errors.http).message,
           https: errors.https,
           http:  errors.http,
         }), servers);

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /*
  * index.js: Create an http AND/OR an https server and call the same request handler.
  *
@@ -45,7 +47,7 @@ module.exports = function createServers(options, listening) {
           if (typeof servers[key] === 'boolean') {
             delete servers[key];
           }
-        })
+        });
 
       if (errors.http || errors.https) {
         return listening(errs.create({
@@ -64,7 +66,7 @@ module.exports = function createServers(options, listening) {
   //
   function createHttp() {
     if (!options.http) {
-      log('http | no options.http; no server')
+      log('http | no options.http; no server');
       return onListen('http');
     }
 
@@ -98,7 +100,7 @@ module.exports = function createServers(options, listening) {
   //
   function createHttps(next) {
     if (!options.https) {
-      log('https | no options.https; no server')
+      log('https | no options.https; no server');
       return onListen('https');
     }
 

--- a/test/create-servers-test.js
+++ b/test/create-servers-test.js
@@ -75,6 +75,26 @@ test('http && https', function (t) {
   });
 });
 
+test('provides useful debug information', function (t) {
+  t.plan(5);
+  createServers({
+    log: console.log,
+    https: {
+      port: 443,
+      root: path.join(__dirname, 'fixtures'),
+      cert: 'agent2-cert.pem',
+      key:  'agent2-key.pem'
+    },
+    handler: fend
+  }, function (err, servers) {
+    t.equals(typeof servers, 'object');
+    t.equals(typeof err, 'object');
+    t.equals(typeof err.https, 'object');
+    t.equals(typeof err.message, 'string');
+    t.notEqual(err.message, 'Unspecified error');
+  });
+});
+
 test('http && https with different handlers', function (t) {
   t.plan(4);
   createServers({


### PR DESCRIPTION
Provide a more useful error message when servers are failing to create by re-using the error message of the original errors instead defaulting to `Unspecified error`. Fixes #5.