### PR TITLE
[fix] default to being more secure with https

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ create-servers
 
 Create an http AND/OR an https server and call the same request handler.
 
+*NOTE on Security*
+Inspired by [`iojs`][iojs] and a well written [article][article], we have defaulted
+our [ciphers][ciphers] to support "perfect-forward-security" as well as removing insecure
+cipher suites from being a possible choice. With this in mind,
+be aware that we will no longer support ie6 on windows XP by default. 
+
 **http**
 ``` js
 var createServers = require('create-servers');
@@ -118,3 +124,7 @@ var servers = createServers(
 
 ### Author: [Charlie Robbins](https://github.com/indexzero)
 ### License: MIT
+
+[article]: https://certsimple.com/blog/a-plus-node-js-ssl
+[iojs]: https://github.com/iojs/io.js
+[ciphers]: https://iojs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,25 @@ var fs = require('fs'),
     connected = require('connected'),
     errs = require('errs');
 
+var CIPHERS = [
+  'ECDHE-RSA-AES256-SHA384',
+  'DHE-RSA-AES256-SHA384',
+  'ECDHE-RSA-AES256-SHA256',
+  'DHE-RSA-AES256-SHA256',
+  'ECDHE-RSA-AES128-SHA256',
+  'DHE-RSA-AES128-SHA256',
+  'HIGH',
+  '!aNULL',
+  '!eNULL',
+  '!EXPORT',
+  '!DES',
+  '!RC4',
+  '!MD5',
+  '!PSK',
+  '!SRP',
+  '!CAMELLIA'
+].join(':');
+
 //
 // ### function createServers (dispatch, options, callback)
 // Creates and listens on both HTTP and HTTPS servers.
@@ -111,6 +130,15 @@ module.exports = function createServers(options, listening) {
         args,
         ip;
 
+    ssl.ciphers = ssl.ciphers || CIPHERS;
+
+    //
+    // Remark: If an array is passed in lets join it like we do the defaults
+    //
+    if (Array.isArray(ssl.ciphers)) {
+      ssl.ciphers = ssl.ciphers.join(':');
+    }
+
     if (ssl.ca && !Array.isArray(ssl.ca)) {
       ssl.ca = [ssl.ca];
     }
@@ -123,7 +151,9 @@ module.exports = function createServers(options, listening) {
         function (file) {
           return fs.readFileSync(path.join(ssl.root, file));
         }
-      )
+      ),
+      ciphers: ssl.ciphers,
+      honorCipherOrder: ssl.honorCipherOrder === false ? false : true
     }, ssl.handler || handler);
 
     args = [server, port];


### PR DESCRIPTION
Enables the proper cipher suites to be properly forward secure and all that jazz. These are the defaults for `iojs` but we should default them here so our users can be more secure.

See https://certsimple.com/blog/a-plus-node-js-ssl