### PR TITLE
Use host in stead of IP and fix logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,7 @@ module.exports = function createServers(options, listening) {
   var handler = options.handler,
       log     = options.log || function () { },
       errors  = {},
-      servers = {},
-      errState;
+      servers = {};
 
   //
   // ### function onListen(type, err, server)
@@ -72,7 +71,7 @@ module.exports = function createServers(options, listening) {
         return listening(errs.create({
           message: (errors.https || errors.http).message,
           https: errors.https,
-          http:  errors.http,
+          http:  errors.http
         }), servers);
       }
 
@@ -160,7 +159,7 @@ module.exports = function createServers(options, listening) {
       // https://certsimple.com/blog/a-plus-node-js-ssl
       //
       ciphers: ssl.ciphers,
-      honorCipherOrder: ssl.honorCipherOrder === false ? false : true,
+      honorCipherOrder: !!ssl.honorCipherOrder,
       //
       // Optionally support SNI-based SSL.
       //

--- a/index.js
+++ b/index.js
@@ -100,12 +100,11 @@ module.exports = function createServers(options, listening) {
 
     var server = http.createServer(options.http.handler || handler),
         port   = options.http.port || 80,
-        args,
-        ip;
+        args;
 
     args = [server, port];
-    if (ip === options.http.ip) {
-      args.push(ip);
+    if (options.http.host) {
+      args.push(options.http.host);
     }
 
     log('http | try listen ' + port);
@@ -173,8 +172,8 @@ module.exports = function createServers(options, listening) {
     }, ssl.handler || handler);
 
     args = [server, port];
-    if (ip === options.https.ip) {
-      args.push(ip);
+    if (options.https.host) {
+      args.push(options.https.host);
     }
 
     args.push(function listener(err) { onListen('https', err, this); });

--- a/test/create-servers-test.js
+++ b/test/create-servers-test.js
@@ -128,13 +128,33 @@ test('http && https with different handlers', function (t) {
     t.plan(3);
     createServers({
       log: console.log,
-      http: "9876",
+      http: '9876',
       handler: fend
     }, function (err, servers) {
       console.dir(err);
       t.error(err);
       t.equals(typeof servers, 'object');
       t.equals(typeof servers.http, 'object');
+      servers.http.close();
+    });
+  });
+
+  test('host can be provided to the server', function (t) {
+    t.plan(4);
+    createServers({
+      log: console.log,
+      http: {
+        port: 9877,
+        host: '127.0.0.1'
+      },
+      handler: fend
+    }, function (err, servers) {
+      console.dir(err);
+      t.error(err);
+      t.equals(typeof servers, 'object');
+      t.equals(typeof servers.http, 'object');
+      t.equals(servers.http.address().address, '127.0.0.1');
+
       servers.http.close();
     });
   });


### PR DESCRIPTION
ip was always `undefined`, so an `undefined` value on the config would also be pushed in. Also `server.listen` expects host, so in stead of using `ip` it makes more sense to set the `host`