### PR TITLE
Fix cert path resolution with absolute paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ results
 
 npm-debug.log
 node_modules
+
+.idea

--- a/index.js
+++ b/index.js
@@ -146,11 +146,11 @@ module.exports = function createServers(options, listening) {
       //
       // Load default SSL key, cert and ca(s).
       //
-      key:  fs.readFileSync(path.join(ssl.root, ssl.key)),
-      cert: fs.readFileSync(path.join(ssl.root, ssl.cert)),
+      key:  fs.readFileSync(path.resolve(ssl.root, ssl.key)),
+      cert: fs.readFileSync(path.resolve(ssl.root, ssl.cert)),
       ca:   ssl.ca && ssl.ca.map(
         function (file) {
-          return fs.readFileSync(path.join(ssl.root, file));
+          return fs.readFileSync(path.resolve(ssl.root, file));
         }
       ),
       //

--- a/test/create-servers-test.js
+++ b/test/create-servers-test.js
@@ -44,7 +44,6 @@ test('only https', function (t) {
     },
     handler: fend
   }, function (err, servers) {
-    console.dir(err);
     t.error(err);
     t.equals(typeof servers, 'object');
     t.equals(typeof servers.https, 'object');
@@ -64,7 +63,6 @@ test('absolute cert path resolution', function (t) {
     },
     handler: fend
   }, function (err, servers) {
-    console.dir(err);
     t.error(err);
     t.equals(typeof servers, 'object');
     t.equals(typeof servers.https, 'object');
@@ -85,7 +83,6 @@ test('http && https', function (t) {
     },
     handler: fend
   }, function (err, servers) {
-    console.dir(err);
     t.error(err);
     t.equals(typeof servers, 'object');
     t.equals(typeof servers.http, 'object');
@@ -135,7 +132,6 @@ test('http && https with different handlers', function (t) {
       key:  'agent2-key.pem'
     },
   }, function (err, servers) {
-    console.dir(err);
     t.error(err);
     t.equals(typeof servers, 'object');
     t.equals(typeof servers.http, 'object');
@@ -151,7 +147,6 @@ test('http && https with different handlers', function (t) {
       http: '9876',
       handler: fend
     }, function (err, servers) {
-      console.dir(err);
       t.error(err);
       t.equals(typeof servers, 'object');
       t.equals(typeof servers.http, 'object');
@@ -169,7 +164,6 @@ test('http && https with different handlers', function (t) {
       },
       handler: fend
     }, function (err, servers) {
-      console.dir(err);
       t.error(err);
       t.equals(typeof servers, 'object');
       t.equals(typeof servers.http, 'object');

--- a/test/create-servers-test.js
+++ b/test/create-servers-test.js
@@ -52,6 +52,26 @@ test('only https', function (t) {
   });
 });
 
+test('absolute cert path resolution', function (t) {
+  t.plan(3);
+  createServers({
+    log: console.log,
+    https: {
+      port: 3456,
+      root: '/',
+      cert: path.resolve(__dirname, 'fixtures', 'agent2-cert.pem'),
+      key:  path.resolve(__dirname, 'fixtures', 'agent2-key.pem')
+    },
+    handler: fend
+  }, function (err, servers) {
+    console.dir(err);
+    t.error(err);
+    t.equals(typeof servers, 'object');
+    t.equals(typeof servers.https, 'object');
+    servers.https.close();
+  });
+});
+
 test('http && https', function (t) {
   t.plan(4);
   createServers({


### PR DESCRIPTION
In our application, we're using `require.resolve` for getting the path of development environment certificates present in an npm module. This causes issues, at least in Windows, because `require.resolve` produces an absolute path, and `path.join` is creating two copies of the root path, for example `C:\C:\Path\To\cert.crt`. By using `path.resolve` instead, both relative and absolute paths are supported for certs.