### PR TITLE
Forward-compatible HTTPS options

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ var fs = require('fs'),
     https = require('https'),
     path = require('path'),
     connected = require('connected'),
-    errs = require('errs');
+    errs = require('errs'),
+    assign = require('object-assign');
 
 var CIPHERS = [
   'ECDHE-RSA-AES256-SHA384',
@@ -143,7 +144,7 @@ module.exports = function createServers(options, listening) {
       ca = [ca];
     }
 
-    var finalHttpsOptions = Object.assign({}, ssl, {
+    var finalHttpsOptions = assign({}, ssl, {
       //
       // Load default SSL key, cert and ca(s).
       //

--- a/index.js
+++ b/index.js
@@ -127,9 +127,6 @@ module.exports = function createServers(options, listening) {
         port = +ssl.port || 443,
         ciphers = ssl.ciphers || CIPHERS,
         ca = ssl.ca,
-        key = fs.readFileSync(path.resolve(ssl.root, ssl.key)),
-        cert = fs.readFileSync(path.resolve(ssl.root, ssl.cert)),
-        honorCipherOrder = !!ssl.honorCipherOrder,
         server,
         args;
 
@@ -148,8 +145,8 @@ module.exports = function createServers(options, listening) {
       //
       // Load default SSL key, cert and ca(s).
       //
-      key: key,
-      cert: cert,
+      key: fs.readFileSync(path.resolve(ssl.root, ssl.key)),
+      cert: fs.readFileSync(path.resolve(ssl.root, ssl.cert)),
       ca: ca && ca.map(
           function (file) {
             return fs.readFileSync(path.resolve(ssl.root, file));
@@ -160,7 +157,7 @@ module.exports = function createServers(options, listening) {
       // https://certsimple.com/blog/a-plus-node-js-ssl
       //
       ciphers: ciphers,
-      honorCipherOrder: honorCipherOrder,
+      honorCipherOrder: !!ssl.honorCipherOrder,
       //
       // Protect against the POODLE attack by disabling SSLv3
       // @see http://googleonlinesecurity.blogspot.nl/2014/10/this-poodle-bites-exploiting-ssl-30.html

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "errs": "~0.3.0"
   },
   "devDependencies": {
+    "sinon": "^1.17.4",
     "tape": "~2.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/indexzero/create-servers",
   "dependencies": {
     "connected": "~0.0.2",
-    "errs": "~0.3.0"
+    "errs": "~0.3.0",
+    "object-assign": "^4.1.0"
   },
   "devDependencies": {
     "sinon": "^1.17.4",

--- a/test/create-servers-test.js
+++ b/test/create-servers-test.js
@@ -7,7 +7,9 @@
 
 var path = require('path'),
     http = require('http'),
+    https = require('https'),
     test = require('tape'),
+    sinon = require('sinon'),
     createServers = require('../');
 
 //
@@ -171,5 +173,26 @@ test('http && https with different handlers', function (t) {
 
       servers.http.close();
     });
+  });
+});
+
+test('supports requestCert https option', function (t) {
+  t.plan(2);
+  var spy = sinon.spy(https, 'createServer');
+  createServers({
+    log: console.log,
+    https: {
+      port:        3456,
+      root:        path.join(__dirname, 'fixtures'),
+      cert:        'agent2-cert.pem',
+      key:         'agent2-key.pem',
+      requestCert: true
+    },
+    handler: fend
+  }, function (err, servers) {
+    t.error(err);
+    t.equals(spy.lastCall.args[0].requestCert, true, 'should preserve the requestCert option');
+    servers.https.close();
+    spy.restore();
   });
 });


### PR DESCRIPTION
I recently discovered that `create-servers` (used by `slay`) was not preserving my `requestCert` option. By changing it to pass through all https options by default, it will now enable client certs and other SSL features which are currently blocked (most likely unintentionally). Also changed the code so it does not mutate the original options.