### PR TITLE
[fix] Allow all keys, certs, ca's to be specified as array

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,6 +190,10 @@ module.exports = function createServers(options, listening) {
  * certificate material read from that file path.
  */
 function normalizeCertFile(root, file) {
+  if (Array.isArray(file)) return file.map(function map(item) {
+    return normalizeCertFile(root, item)
+  });
+
   //
   // Assumption that this is a Buffer, a PEM file, or something broken
   //

--- a/test/create-servers-test.js
+++ b/test/create-servers-test.js
@@ -254,6 +254,26 @@ test('supports cert contents instead of cert paths', function (t) {
   });
 });
 
+test('supports cert array instead of strings', function (t) {
+  t.plan(3);
+  var root = path.join(__dirname, 'fixtures');
+  createServers({
+    log: console.log,
+    https: {
+      port: 3456,
+      root: root,
+      cert: [fs.readFileSync(path.resolve(root, 'agent2-cert.pem'))],
+      key:  fs.readFileSync(path.resolve(root, 'agent2-key.pem'))
+    },
+    handler: fend
+  }, function (err, servers) {
+    t.error(err);
+    t.equals(typeof servers, 'object');
+    t.equals(typeof servers.https, 'object');
+    servers.https.close();
+  });
+});
+
 test('supports requestCert https option', function (t) {
   t.plan(2);
   var spy = sinon.spy(https, 'createServer');


### PR DESCRIPTION
As per title, SSL properties such as `key`, `cert`, `ca` allow for [multiple values to be specified](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options). This change will allow arrays to be specified in addition to the strings we already supported. 