### PR TITLE
Reuse secure contexts for SNI

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,13 +268,13 @@ function getSNIHandler(sslOpts) {
     );
   });
 
-  // Prepare secure context params ahead-of-time
-  var hostTlsOpts = sniHosts.map(function (host) {
+  // Prepare secure contexts ahead-of-time
+  var hostSecureContexts = sniHosts.map(function (host) {
     var hostOpts = sslOpts.sni[host];
 
     var root = hostOpts.root || sslOpts.root;
 
-    return assign({}, sslOpts, hostOpts, {
+    return tls.createSecureContext(assign({}, sslOpts, hostOpts, {
       key: normalizePEMContent(root, hostOpts.key),
       cert: normalizeCertContent(root, hostOpts.cert),
       ca: normalizeCA(root, hostOpts.ca || sslOpts.ca),
@@ -282,7 +282,7 @@ function getSNIHandler(sslOpts) {
       honorCipherOrder: !!(hostOpts.honorCipherOrder || sslOpts.honorCipherOrder),
       secureProtocol: 'SSLv23_method',
       secureOptions: secureOptions
-    });
+    }));
   });
 
   return function (hostname, cb) {
@@ -294,6 +294,6 @@ function getSNIHandler(sslOpts) {
       return void cb(new Error('Unrecognized hostname: ' + hostname));
     }
 
-    cb(null, tls.createSecureContext(hostTlsOpts[matchingHostIdx]));
+    cb(null, hostSecureContexts[matchingHostIdx]);
   };
 }

--- a/test/create-servers-test.js
+++ b/test/create-servers-test.js
@@ -107,8 +107,8 @@ test('only https', function (t) {
     https: {
       port: 3456,
       root: path.join(__dirname, 'fixtures'),
-      cert: 'agent2-cert.pem',
-      key:  'agent2-key.pem'
+      key: 'example-org-key.pem',
+      cert: 'example-org-cert.pem'
     },
     handler: fend
   }, function (err, servers) {
@@ -128,8 +128,8 @@ test('only https', function (t) {
       timeout: time,
       port: 3456,
       root: path.join(__dirname, 'fixtures'),
-      cert: 'agent2-cert.pem',
-      key:  'agent2-key.pem'
+      key: 'example-org-key.pem',
+      cert: 'example-org-cert.pem'
     },
     handler: fend
   }, function (err, servers) {
@@ -148,8 +148,8 @@ test('absolute cert path resolution', function (t) {
     https: {
       port: 3456,
       root: '/',
-      cert: path.resolve(__dirname, 'fixtures', 'agent2-cert.pem'),
-      key:  path.resolve(__dirname, 'fixtures', 'agent2-key.pem')
+      cert: path.resolve(__dirname, 'fixtures', 'example-org-cert.pem'),
+      key:  path.resolve(__dirname, 'fixtures', 'example-org-key.pem')
     },
     handler: fend
   }, function (err, servers) {
@@ -168,8 +168,8 @@ test('http && https', function (t) {
     https: {
       port: 3456,
       root: path.join(__dirname, 'fixtures'),
-      cert: 'agent2-cert.pem',
-      key:  'agent2-key.pem'
+      key: 'example-org-key.pem',
+      cert: 'example-org-cert.pem'
     },
     handler: fend
   }, function (err, servers) {
@@ -189,8 +189,8 @@ test('provides useful debug information', function (t) {
     https: {
       port: 443,
       root: path.join(__dirname, 'fixtures'),
-      cert: 'agent2-cert.pem',
-      key:  'agent2-key.pem'
+      key: 'example-org-key.pem',
+      cert: 'example-org-cert.pem'
     },
     handler: fend
   }, function (err, servers) {
@@ -218,8 +218,8 @@ test('http && https with different handlers', function (t) {
       },
       port: 3456,
       root: path.join(__dirname, 'fixtures'),
-      cert: 'agent2-cert.pem',
-      key:  'agent2-key.pem'
+      key: 'example-org-key.pem',
+      cert: 'example-org-cert.pem'
     },
   }, function (err, servers) {
     t.error(err);
@@ -272,8 +272,8 @@ test('supports cert contents instead of cert paths', function (t) {
     https: {
       port: 3456,
       root: root,
-      cert: fs.readFileSync(path.resolve(root, 'agent2-cert.pem')),
-      key:  fs.readFileSync(path.resolve(root, 'agent2-key.pem'))
+      cert: fs.readFileSync(path.resolve(root, 'example-org-cert.pem')),
+      key:  fs.readFileSync(path.resolve(root, 'example-org-key.pem'))
     },
     handler: fend
   }, function (err, servers) {
@@ -292,8 +292,8 @@ test('supports cert array instead of strings', function (t) {
     https: {
       port: 3456,
       root: root,
-      cert: [fs.readFileSync(path.resolve(root, 'agent2-cert.pem'))],
-      key:  fs.readFileSync(path.resolve(root, 'agent2-key.pem'))
+      key: 'example-org-key.pem',
+      cert: 'example-org-cert.pem'
     },
     handler: fend
   }, function (err, servers) {
@@ -337,10 +337,10 @@ test('supports requestCert https option', function (t) {
   createServers({
     log: console.log,
     https: {
-      port:        3456,
-      root:        path.join(__dirname, 'fixtures'),
-      cert:        'agent2-cert.pem',
-      key:         'agent2-key.pem',
+      port: 3456,
+      root: path.join(__dirname, 'fixtures'),
+      key: 'example-org-key.pem',
+      cert: 'example-org-cert.pem',
       requestCert: true
     },
     handler: fend


### PR DESCRIPTION
* Reuse secure contexts instead of creating new ones for each SNI connection
* Substitute certificates that cause `ee key too small` errors for newer versions of Node